### PR TITLE
[NO_TICKET] - Documentation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Before requesting assistance, please review our [API documentation](https://thet
 
 For API related issues or questions, please use the github [issue tracker](https://github.com/thetvdb/v4-api/issues).
 
-##Postman collections
-
+## Postman collections
 - [Postman](https://www.getpostman.com/collections/7a9397ce69ff246f74d0)
 
 ## Official Libraries

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -16,7 +16,7 @@ security:
 paths:
   /login:
     post:
-      summary: create an auth token. The token has one month valition length.
+      summary: create an auth token. The token has one month validation length.
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
I amended the README so that the heading for the Postman collections rendered correctly.

## Before
<img width="899" alt="Screenshot 2023-02-27 at 06 02 33" src="https://user-images.githubusercontent.com/356955/221489246-3fb33cf6-b708-4401-98d1-f9f3ff20f28e.png">

## After
<img width="895" alt="Screenshot 2023-02-27 at 06 03 39" src="https://user-images.githubusercontent.com/356955/221489286-6d411aa6-8a0b-4c60-bccf-403a9b017278.png">

I also amended what I think is a type/misspelling in the swagger for the length of time an auth token is valid for.