### PR TITLE
Fix: Added missing nullables in Company, MovieBaseRecord, MovieExtendedRecord schemas

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -2679,6 +2679,7 @@ components:
           format: int64
           type: integer
           x-go-name: PrimaryCompanyType
+          nullable: true
         slug:
           type: string
           x-go-name: Slug
@@ -3233,6 +3234,7 @@ components:
           $ref: '#/components/schemas/Status'
         runtime:
           type: integer
+          nullable: true
         year:
           type: string
       type: object
@@ -3338,6 +3340,7 @@ components:
           x-go-name: RemoteIDs
         runtime:
           type: integer
+          nullable: true
         score:
           format: double
           type: number


### PR DESCRIPTION
Added missing nullables in Company, MovieBaseRecord, MovieExtendedRecord schemas as mentioned in my second comment in https://github.com/thetvdb/v4-api/issues/314