### PR TITLE
Set some fields to nullable in Link

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -4250,10 +4250,12 @@ components:
       properties:
         prev:
           type: string
+          nullable: true
         self:
           type: string
         next:
           type: string
+          nullable: true
         total_items:
           type: integer
         page_size:


### PR DESCRIPTION
The properties `prev` and `next` in `Links` can be returned as `null` which gives errors with some API generators on runtime (https://github.com/astahmer/openapi-zod-client)